### PR TITLE
Add :custom_fields option for injecting custom data from consumer app

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,15 @@ add below lines to config/initializers/exception_notification.rb.
     color: :danger, # optional, default to :danger
     additional_parameters: {
       icon_emoji: ':warning:'
-    }
+    },
+    custom_fields: [
+      {
+        title: 'User Agent',
+        value: ->(req) { req.user_agent },
+        short: false,
+        after: 'IP Address'
+      }
+    ]
   }
 ```
 

--- a/spec/exception_notification/slacky_spec.rb
+++ b/spec/exception_notification/slacky_spec.rb
@@ -14,6 +14,10 @@ describe ExceptionNotification::Slacky do
     end
   end
 
+  let(:user_agent) do
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A403 Safari/8536.25'
+  end
+
   let(:fake_notification) do
     [
       'Exception Occured!',
@@ -28,6 +32,7 @@ describe ExceptionNotification::Slacky do
             { title: 'Request path',  value: '/foo/bar',                short: true  },
             { title: 'HTTP Method',   value: 'POST',                    short: true  },
             { title: 'IP Address',    value: '127.0.0.1',               short: true  },
+            { title: 'User Agent',    value: user_agent,                short: false },
             { title: 'Occurred on',   value: exception.backtrace.first, short: false },
             { title: 'Error message', value: exception.message,         short: false }
           ]
@@ -48,12 +53,27 @@ describe ExceptionNotification::Slacky do
         channel: '#general',
         additional_parameters: {
           icon_emoji: ':warning:'
-        }
+        },
+        custom_fields: [
+          {
+            title: 'User Agent',
+            value: ->(req) { req.user_agent },
+            short: false,
+            after: 'IP Address'
+          }
+        ]
       }
     end
 
     let(:rack_options) do
-      { env: { 'PATH_INFO' => '/foo/bar', 'REQUEST_METHOD' => 'POST', 'REMOTE_ADDR' => '127.0.0.1' } }
+      {
+        env: {
+          'PATH_INFO'       => '/foo/bar',
+          'REQUEST_METHOD'  => 'POST',
+          'REMOTE_ADDR'     => '127.0.0.1',
+          'HTTP_USER_AGENT' => user_agent
+        }
+      }
     end
 
     describe 'Notification format' do


### PR DESCRIPTION
Hi, @morygonzalez :crescent_moon:

I want to customize the original fields, for example "USER AGENT", "REVISION" and other.

 So `:custom_fields` is added, and it will be used in the following:

```rb
custom_fields: [
  {
    title: 'REVISION',
    value: ->(_) { Rails.root.join('REVISION').read.chomp },
    short: true,
    after: 'IPAddress'
  },
  {
    title: 'User Agent',
    value: ->(req) { req.user_agent },
    short: false,
    after: 'REVISION'
  }
]
```

How is it?