### PR TITLE
Bug fix when manual notify

### DIFF
--- a/lib/exception_notifier/slacky_notifier.rb
+++ b/lib/exception_notifier/slacky_notifier.rb
@@ -59,7 +59,7 @@ module ExceptionNotifier
         },
         {
           title: "HTTP Method",
-          value: @request.request_method,
+          value: (@request.request_method rescue nil),
           short: true
         },
         {

--- a/spec/exception_notification/slacky_spec.rb
+++ b/spec/exception_notification/slacky_spec.rb
@@ -93,5 +93,40 @@ describe ExceptionNotification::Slacky do
       it { expect(slack_notifier.notifier.username).to eq('slacky') }
       it { expect(slack_notifier.notifier.default_payload[:additional_parameters][:icon_emoji]).to eq(':warning:') }
     end
+
+    context 'when manually' do
+      let(:rack_options) do
+        {
+          env: {}
+        }
+      end
+
+
+      describe 'Notification format' do
+        before do
+          fields = fake_notification.last[:attachments][0][:fields]
+          fields[1][:value] = ""  # Request Path
+          fields[2][:value] = nil # HTTP Method
+          fields[3][:value] = nil # IP Address
+          fields[4][:value] = nil # User Agent
+        end
+
+        it {
+          allow_any_instance_of(Slack::Notifier).to receive(:ping).with(*fake_notification)
+          slack_notifier.call(exception, rack_options)
+        }
+      end
+
+      describe 'Options' do
+        before do
+          stub_request(:any, options[:webhook_url])
+          slack_notifier.call(exception, rack_options)
+        end
+
+        it { expect(slack_notifier.notifier.channel).to eq('#general') }
+        it { expect(slack_notifier.notifier.username).to eq('slacky') }
+        it { expect(slack_notifier.notifier.default_payload[:additional_parameters][:icon_emoji]).to eq(':warning:') }
+      end
+    end
   end
 end


### PR DESCRIPTION
# Problem

以下のように `ExceptionNotifier` をマニュアル実行しようとすると、例外を吐いてしまいます。
rails console で検証しています。

``` ruby
irb > e = StandardError.new "hoge"
irb > ExceptionNotifier.notify_exception e
An error occurred when sending a notification using 'slacky' notifier. ActionController::UnknownHttpMethod: , accepted HTTP methods are OPTIONS, GET, HEAD, POST, PUT, DELETE, TRACE, CONNECT, PROPFIND, PROPPATCH, MKCOL, COPY, MOVE, LOCK, UNLOCK, VERSION-CONTROL, REPORT, CHECKOUT, CHECKIN, UNCHECKOUT, MKWORKSPACE, UPDATE, LABEL, MERGE, BASELINE-CONTROL, MKACTIVITY, ORDERPATCH, ACL, SEARCH, MKCALENDAR, and PATCH
/home/pocke/.gem/ruby/2.3.0/gems/actionpack-4.2.4/lib/action_dispatch/http/request.rb:344:in `check_method'
/home/pocke/.gem/ruby/2.3.0/gems/actionpack-4.2.4/lib/action_dispatch/http/request.rb:105:in `request_method'
/home/pocke/.gem/ruby/2.3.0/gems/exception_notification-slacky-0.1.2/lib/exception_notifier/slacky_notifier.rb:62:in `build_fields'
/home/pocke/.gem/ruby/2.3.0/gems/exception_notification-slacky-0.1.2/lib/exception_notifier/slacky_notifier.rb:44:in `build_attachemnt'
/home/pocke/.gem/ruby/2.3.0/gems/exception_notification-slacky-0.1.2/lib/exception_notifier/slacky_notifier.rb:26:in `call'
/home/pocke/.gem/ruby/2.3.0/gems/exception_notification-4.1.4/lib/exception_notifier.rb:95:in `fire_notification'
/home/pocke/.gem/ruby/2.3.0/gems/exception_notification-4.1.4/lib/exception_notifier.rb:40:in `block in notify_exception'
/home/pocke/.gem/ruby/2.3.0/gems/exception_notification-4.1.4/lib/exception_notifier.rb:39:in `each'
/home/pocke/.gem/ruby/2.3.0/gems/exception_notification-4.1.4/lib/exception_notifier.rb:39:in `notify_exception'
(irb):5:in `irb_binding'
/usr/lib/ruby/2.3.0/irb/workspace.rb:87:in `eval'
/usr/lib/ruby/2.3.0/irb/workspace.rb:87:in `evaluate'
/usr/lib/ruby/2.3.0/irb/context.rb:380:in `evaluate'
/usr/lib/ruby/2.3.0/irb.rb:489:in `block (2 levels) in eval_input'
/usr/lib/ruby/2.3.0/irb.rb:623:in `signal_status'
/usr/lib/ruby/2.3.0/irb.rb:486:in `block in eval_input'
/usr/lib/ruby/2.3.0/irb/ruby-lex.rb:246:in `block (2 levels) in each_top_level_statement'
/usr/lib/ruby/2.3.0/irb/ruby-lex.rb:232:in `loop'
/usr/lib/ruby/2.3.0/irb/ruby-lex.rb:232:in `block in each_top_level_statement'
/usr/lib/ruby/2.3.0/irb/ruby-lex.rb:231:in `catch'
/usr/lib/ruby/2.3.0/irb/ruby-lex.rb:231:in `each_top_level_statement'
/usr/lib/ruby/2.3.0/irb.rb:485:in `eval_input'
/usr/lib/ruby/2.3.0/irb.rb:395:in `block in start'
/usr/lib/ruby/2.3.0/irb.rb:394:in `catch'
/usr/lib/ruby/2.3.0/irb.rb:394:in `start'
/home/pocke/.gem/ruby/2.3.0/gems/railties-4.2.4/lib/rails/commands/console.rb:110:in `start'
/home/pocke/.gem/ruby/2.3.0/gems/railties-4.2.4/lib/rails/commands/console.rb:9:in `start'
/home/pocke/.gem/ruby/2.3.0/gems/railties-4.2.4/lib/rails/commands/commands_tasks.rb:68:in `console'
/home/pocke/.gem/ruby/2.3.0/gems/railties-4.2.4/lib/rails/commands/commands_tasks.rb:39:in `run_command!'
/home/pocke/.gem/ruby/2.3.0/gems/railties-4.2.4/lib/rails/commands.rb:17:in `<top (required)>'
bin/rails:4:in `require'
bin/rails:4:in `<main>'
=> true
```
# 対応

`@request.request_method` が例外を吐いているので、それを抑止しました。
